### PR TITLE
添加了admin 布局的 layadmin-pagetabs 的 tabs 导航 和图标的颜色问题

### DIFF
--- a/dist/layui-theme-dark-legacy.css
+++ b/dist/layui-theme-dark-legacy.css
@@ -37,6 +37,8 @@ a:hover{color:rgba(255,255,255,.5)}
 .layui-layout-admin .layui-header{background-color:#232324}
 .layui-layout-admin .layui-footer{box-shadow:-1px 0 4px rgb(0 0 0 / 12%);background-color:#232324}
 .layui-layout-admin .layui-logo{color:#16BAAA;box-shadow:0 1px 2px 0 rgb(0 0 0 / 15%)}
+.layui-layout-admin .layadmin-pagetabs {background-color:#232324}
+    .layui-layout-admin .layadmin-pagetabs .layui-tab .layui-tab-title li {background-color:#232324}
 /* 引用 */
 .layui-elem-quote{border-left:5px solid #16B777;background-color:rgba(255,255,255,.04);filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0affffff', endColorstr='#0affffff')}
 :root .layui-elem-quote{filter: none\9

--- a/dist/layui-theme-dark.css
+++ b/dist/layui-theme-dark.css
@@ -219,6 +219,8 @@ a:hover{color:var(--lay-color-text-3)}
 .layui-layout-admin .layui-header{background-color:var(--lay-color-bg-2)}
 .layui-layout-admin .layui-footer{box-shadow:-1px 0 4px rgb(0 0 0 / 12%);background-color:var(--lay-color-bg-2)}
 .layui-layout-admin .layui-logo{color:var(--lay-color-primary);box-shadow:0 1px 2px 0 rgb(0 0 0 / 15%)}
+.layui-layout-admin .layadmin-pagetabs {background-color:var(--lay-color-bg-2)}
+    .layui-layout-admin .layadmin-pagetabs .layui-tab .layui-tab-title li {background-color:var(--lay-color-bg-2)}
 /* 引用 */
 .layui-elem-quote{border-left:5px solid var(--lay-color-secondary);background-color:var(--lay-color-fill-1)}
 .layui-quote-nm{border-color: var(--lay-color-fill-1)}

--- a/src/override.css
+++ b/src/override.css
@@ -17,6 +17,8 @@ a:hover{color:var(--lay-color-text-3)}
 .layui-layout-admin .layui-header{background-color:var(--lay-color-bg-2)}
 .layui-layout-admin .layui-footer{box-shadow:-1px 0 4px rgb(0 0 0 / 12%);background-color:var(--lay-color-bg-2)}
 .layui-layout-admin .layui-logo{color:var(--lay-color-primary);box-shadow:0 1px 2px 0 rgb(0 0 0 / 15%)}
+.layui-layout-admin .layadmin-pagetabs {background-color:var(--lay-color-bg-2)}
+    .layui-layout-admin .layadmin-pagetabs .layui-tab .layui-tab-title li {background-color:var(--lay-color-bg-2)}
 /* 引用 */
 .layui-elem-quote{border-left:5px solid var(--lay-color-secondary);background-color:var(--lay-color-fill-1)}
 .layui-quote-nm{border-color: var(--lay-color-fill-1)}


### PR DESCRIPTION
<section class="layadmin-pagetabs" id="LAY_app_tabs">
    <div class="layui-icon layadmin-tabs-control layui-icon-prev" layadmin-event="leftPage"></div>
    <div class="layui-icon layadmin-tabs-control layui-icon-next" layadmin-event="rightPage"></div>
    <div class="layui-icon layadmin-tabs-control layui-icon-down">
        <ul class="layui-nav layadmin-tabs-select" lay-filter="layadmin-pagetabs-nav">
            <li class="layui-nav-item" lay-unselect="">
                <a href="javascript:;"><i class="layui-icon layui-icon-down layui-nav-more"></i></a>
                <dl class="layui-nav-child layui-anim-fadein">
                    <dd layadmin-event="closeThisTabs"><a href="javascript:;">关闭当前标签页</a></dd>
                    <dd layadmin-event="closeOtherTabs"><a href="javascript:;">关闭其它标签页</a></dd>
                    <dd layadmin-event="closeAllTabs"><a href="javascript:;">关闭全部标签页</a></dd>
                </dl>
            </li>
        <span class="layui-nav-bar"></span></ul>
    </div>
    <div class="layui-tab" lay-unauto="" lay-allowclose="true" lay-filter="layadmin-layout-tabs">
        <ul class="layui-tab-title" id="LAY_app_tabsheader">
            <li lay-id="/Home/Console" lay-attr="/Home/Console" class="layui-this"><i class="layui-icon layui-icon-home"></i><i class="layui-icon layui-icon-close layui-unselect layui-tab-close"></i></li>
        </ul>
    </div>
</section>