### PR TITLE
fix: 优化 Demo 页面初始样式错乱问题

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,8 +7,14 @@ const rootPath = (function (src) {
   src = document.currentScript ? document.currentScript.src : document.scripts[document.scripts.length - 1].src;
   return src.substring(0, src.lastIndexOf('/') + 1);
 })();
-addLink({ href: layuicss });
+
+const app = document.querySelector('#app')
+
+addLink({ href: layuicss }).then(() => {
+  app.style.display = 'block';
+});
 addLink({ id: 'layui_theme_css', href: '' });
+
 loadScript(layuijs, function () {
   layui
     .config({
@@ -133,7 +139,7 @@ loadScript(layuijs, function () {
         clearTimeout(loadTimer);
         layer.closeLast('loading');
       })
-      
+
       // 选中, 展开菜单
       $('#ws-nav-side')
         .find("[data-path='" + path + "']")
@@ -181,11 +187,15 @@ function addStyle(id, cssStr) {
 }
 
 function addLink(opt) {
-  const link = document.createElement('link');
-  link.id = opt.id;
-  link.rel = 'stylesheet';
-  link.href = opt.href;
-  document.head.appendChild(link);
+  return new Promise((resolve) => {
+    const link = Object.assign(document.createElement('link'), {
+      rel: 'stylesheet',
+      onload: () => resolve({ ...opt, status: 'success' }),
+      onerror: () => resolve({ ...opt, status: 'error' }), // 为了在 Promise.all 的使用场景
+      ...opt,
+    });
+    document.head.appendChild(link);
+  });
 }
 
 function loadScript(url, callback) {

--- a/index.html
+++ b/index.html
@@ -9,6 +9,11 @@
         padding: 15px;
         display: block;
       }
+
+      #app {
+        display: none;
+      }
+
       .layui-layout-right .layui-nav-bar {
         background-color: unset !important;
       }
@@ -68,7 +73,7 @@
   </head>
 
   <body>
-    <div class="layui-layout layui-layout-admin">
+    <div class="layui-layout layui-layout-admin" id="app">
       <div class="layui-header">
         <!-- 头部区域（可配合layui 已有的水平导航） -->
         <ul class="layui-nav layui-layout-left">


### PR DESCRIPTION
### 改进前
![image](https://github.com/user-attachments/assets/190d18f1-dca8-4d4d-9f33-b86154f26618)

### 改进后
根据 Layui 样式加载完毕后再显示主容器，避免初始加载时的样式错乱。