### PR TITLE
fix: 修复使用选择器模式时的部分组件样式异常问题

### DIFF
--- a/src/override.css
+++ b/src/override.css
@@ -232,7 +232,6 @@ body .layui-table-tips .layui-layer-content{box-shadow:var(--lay-shadow-3)}
 .layui-menu .layui-menu-item-none{color: var(--lay-color-text-3);}
 .layui-menu .layui-menu-item-group:hover,
 .layui-menu .layui-menu-item-none:hover,
-.layui-menu .layui-menu-item-none{color: var(--lay-color-black);}
 .layui-menu .layui-menu-item-divider{border-bottom:1px solid var(--lay-color-border-2)}
 .layui-menu .layui-menu-item-divider:hover{background: none;}
 .layui-menu .layui-menu-item-up>.layui-menu-body-title{color: var(--lay-color-text-1)}

--- a/src/override.css
+++ b/src/override.css
@@ -229,8 +229,12 @@ body .layui-table-tips .layui-layer-content{box-shadow:var(--lay-shadow-3)}
 .layui-menu li:hover{background-color: var(--lay-color-bg-5)}
 .layui-menu li.layui-disabled,.layui-menu li.layui-disabled *{color:var(--lay-color-text-4)!important}
 .layui-menu .layui-menu-item-group>.layui-menu-body-title{color: var(--lay-color-text-3)}
-.layui-menu .layui-menu-item-none{color:var(--lay-color-black)}
+.layui-menu .layui-menu-item-none{color: var(--lay-color-text-3);}
+.layui-menu .layui-menu-item-group:hover,
+.layui-menu .layui-menu-item-none:hover,
+.layui-menu .layui-menu-item-none{color: var(--lay-color-black);}
 .layui-menu .layui-menu-item-divider{border-bottom:1px solid var(--lay-color-border-2)}
+.layui-menu .layui-menu-item-divider:hover{background: none;}
 .layui-menu .layui-menu-item-up>.layui-menu-body-title{color: var(--lay-color-text-1)}
 .layui-menu .layui-menu-item-down:hover>.layui-menu-body-title>.layui-icon,.layui-menu .layui-menu-item-up>.layui-menu-body-title:hover>.layui-icon{color: var(--lay-color-text-1)}
 .layui-menu .layui-menu-item-checked,.layui-menu .layui-menu-item-checked2{background-color:var(--lay-color-active)!important;color:var(--lay-color-secondary)}
@@ -254,7 +258,7 @@ body .layui-table-tips .layui-layer-content{box-shadow:var(--lay-shadow-3)}
 .layui-nav-tree .layui-nav-child dd.layui-this,.layui-nav-tree .layui-nav-child dd.layui-this a,.layui-nav-tree .layui-this,.layui-nav-tree .layui-this>a,.layui-nav-tree .layui-this>a:hover{background-color: var(--lay-color-primary);color: var(--lay-color-white)}
 .layui-nav-itemed>a,.layui-nav-tree .layui-nav-title a,.layui-nav-tree .layui-nav-title a:hover{color: var(--lay-color-white)!important}
 .layui-nav-tree .layui-nav-bar{background-color:var(--lay-color-primary)}
-.layui-nav-tree .layui-nav-child{background: none;background-color:rgba(0, 0, 0, .3)}
+.layui-nav-tree .layui-nav-child{background: none; background-color:rgba(0, 0, 0, .3); border: none; box-shadow: none;}
 .layui-nav-tree .layui-nav-child a{color: var(--lay-color-white);color: var(--lay-color-text-1)}
 .layui-nav-tree .layui-nav-child a:hover{background: none; color: var(--lay-color-white)}
 .layui-nav.layui-bg-gray,.layui-nav-tree.layui-bg-gray{background-color: var(--lay-color-bg-2) !important;color: var(--lay-color-text-1);}

--- a/src/override.css
+++ b/src/override.css
@@ -230,9 +230,9 @@ body .layui-table-tips .layui-layer-content{box-shadow:var(--lay-shadow-3)}
 .layui-menu li.layui-disabled,.layui-menu li.layui-disabled *{color:var(--lay-color-text-4)!important}
 .layui-menu .layui-menu-item-group>.layui-menu-body-title{color: var(--lay-color-text-3)}
 .layui-menu .layui-menu-item-none{color: var(--lay-color-text-3);}
+.layui-menu .layui-menu-item-divider{border-bottom:1px solid var(--lay-color-border-2)}
 .layui-menu .layui-menu-item-group:hover,
 .layui-menu .layui-menu-item-none:hover,
-.layui-menu .layui-menu-item-divider{border-bottom:1px solid var(--lay-color-border-2)}
 .layui-menu .layui-menu-item-divider:hover{background: none;}
 .layui-menu .layui-menu-item-up>.layui-menu-body-title{color: var(--lay-color-text-1)}
 .layui-menu .layui-menu-item-down:hover>.layui-menu-body-title>.layui-icon,.layui-menu .layui-menu-item-up>.layui-menu-body-title:hover>.layui-icon{color: var(--lay-color-text-1)}


### PR DESCRIPTION
### 触发场景
使用选择器切换深色主题时
```
document.documentElement.classList.add('dark')
```

### 问题展示
- 垂直导航子菜单出现边框阴影
![image](https://github.com/user-attachments/assets/ad9eaca0-633c-47e5-90e9-09de60b49c11)

- 基础菜单 hover 到「垂直菜单组」时出现背景色
![image](https://github.com/user-attachments/assets/25752d44-899e-49c7-b008-cf9326ff124d)

- dropdown 无数据时的文字颜色异常
![image](https://github.com/user-attachments/assets/871af857-819f-4d05-96e3-450321f65fd8)


