### PR TITLE
fix: 修复 table 分页样式异常

### DIFF
--- a/src/override.css
+++ b/src/override.css
@@ -188,6 +188,8 @@ a:hover{color:var(--lay-color-text-3)}
 .layui-table-view .layui-table td[data-edit]:hover:after{border:1px solid var(--lay-color-primary-active)}
 .layui-table-loading-icon .layui-icon{color:var(--lay-color-gray-8);}
 .layui-table-page{background-color: var(--lay-color-bg-2);}
+.layui-table-page .layui-laypage a,
+.layui-table-page .layui-laypage span{border: none;}
 .layui-table-tool{background-color: var(--lay-color-bg-2);}
 .layui-table-tool .layui-inline[lay-event]{color:var(--lay-color-text-3);border:1px solid var(--lay-color-border-2)}
 .layui-table-tool .layui-inline[lay-event]:hover{border:1px solid var(--lay-color-border-3)}


### PR DESCRIPTION
### 问题描述
使用选择器切换到深色主题模式下，table 分页样式异常，如下所示：

![error](https://github.com/user-attachments/assets/cb78448b-28a5-4a1a-a6c5-a8bfed4be7d4)

**原因**：添加选择器后 https://github.com/Sight-wcg/layui-theme-dark/blob/3fe94b2f55a19fb84dcc4050db009da7454d7fb3/dist/layui-theme-dark-selector.css#L803-L809 
上述样式优先级高于 https://github.com/layui/layui/blob/4c239a89212bbba06c277eba7563b5e78bc31543/src/css/layui.css#L1150-L1151 所致

### 本次变更
- 提升 `.layui-table-page .layui-laypage :is(a, span)` 优先级

预期：

![ok](https://github.com/user-attachments/assets/86af12c6-f4a2-4272-9e4d-8179dc96d599)
