### PR TITLE
fix: laydate footer hover color

### DIFF
--- a/dist/layui-theme-dark-legacy.css
+++ b/dist/layui-theme-dark-legacy.css
@@ -578,7 +578,7 @@ body .layui-util-face .layui-layer-content{background-color: #373739;color:rgba(
 .layui-laydate-footer span{border:1px solid  #484849;background-color: #373739}
 .layui-laydate-footer span:hover{color:#16B777}
 .layui-laydate-footer span.layui-laydate-preview{border-color:transparent!important;}
-.layui-laydate-footer span.layui-laydate-preview:hover{color:#23303C}
+.layui-laydate-footer span.layui-laydate-preview:hover{color:rgba(255,255,255,.9)}
 .layui-laydate-shortcut+.layui-laydate-main{border-left:1px solid  #484849}
 .layui-laydate .layui-laydate-list{background-color: #373739}
 .layui-laydate-hint{color:#FF5722}

--- a/dist/layui-theme-dark-selector.css
+++ b/dist/layui-theme-dark-selector.css
@@ -1527,7 +1527,7 @@
   border-color: transparent!important;
 }
 .dark .layui-laydate-footer span.layui-laydate-preview:hover {
-  color: var(--lay-color-black-7);
+  color: var(--lay-color-text-1);
 }
 .dark .layui-laydate-shortcut + .layui-laydate-main {
   border-left: 1px solid var(--lay-color-border-2);

--- a/dist/layui-theme-dark.css
+++ b/dist/layui-theme-dark.css
@@ -600,7 +600,7 @@ body .layui-util-face .layui-layer-content{background-color: var(--lay-color-bg-
 .layui-laydate-footer span{border:1px solid  var(--lay-color-border-2);background-color: var(--lay-color-bg-5)}
 .layui-laydate-footer span:hover{color:var(--lay-color-secondary)}
 .layui-laydate-footer span.layui-laydate-preview{border-color:transparent!important;}
-.layui-laydate-footer span.layui-laydate-preview:hover{color:var(--lay-color-black-7)}
+.layui-laydate-footer span.layui-laydate-preview:hover{color:var(--lay-color-text-1)}
 .layui-laydate-shortcut+.layui-laydate-main{border-left:1px solid  var(--lay-color-border-2)}
 .layui-laydate .layui-laydate-list{background-color: var(--lay-color-bg-5)}
 .layui-laydate-hint{color:var(--lay-color-danger)}

--- a/src/override.css
+++ b/src/override.css
@@ -398,7 +398,7 @@ body .layui-util-face .layui-layer-content{background-color: var(--lay-color-bg-
 .layui-laydate-footer span{border:1px solid  var(--lay-color-border-2);background-color: var(--lay-color-bg-5)}
 .layui-laydate-footer span:hover{color:var(--lay-color-secondary)}
 .layui-laydate-footer span.layui-laydate-preview{border-color:transparent!important;}
-.layui-laydate-footer span.layui-laydate-preview:hover{color:var(--lay-color-black-7)}
+.layui-laydate-footer span.layui-laydate-preview:hover{color:var(--lay-color-text-1)}
 .layui-laydate-shortcut+.layui-laydate-main{border-left:1px solid  var(--lay-color-border-2)}
 .layui-laydate .layui-laydate-list{background-color: var(--lay-color-bg-5)}
 .layui-laydate-hint{color:var(--lay-color-danger)}


### PR DESCRIPTION
### 问题说明

- 根据 `laydate.css:113` 规定 `.layui-laydate` 及其后代 `color` 为 `#777`, 样式计算得 `rgb(119, 119, 119)`
- 根据 `laydate.css:72` 规定 `.layui-laydate-footer span.layui-laydate-preview:hover` 及其后代 `color` 为 `#777`, 样式计算得 `rgb(119, 119, 119)`
经简单确认可知该选择器对应的元素在是否带有 `:hover` 的情况下 `color` 一致

+ 根据 `layui-theme-dark.css:608` (`override.css:406`) 规定 `.layui-laydate` 及其后代 `color` 为 `var(--lay-color-text-1)`, 样式计算得 `rgba(255,255,255,.9)`
+ 根据 `layui-theme-dark.css:603` (`override.css:401`) 规定`.layui-laydate-footer span.layui-laydate-preview:hover` 及其后代 `color` 为 `var(--lay-color-black-7)`, 样式计算得 `rgb(35, 48, 60)`
+ 经简单比较可知该选择器对应的元素在带有 `:hover` 的情况下 `color` 不一致

### 更改说明

- 通过将  `layui-theme-dark.css:603` (`override.css:401`) 处的 `color` 修改至与前一个选择器的 `color` 相同, 以达到原样式的效果
- 若不进行修改, 则在 `:hover` 时将导致文本颜色与背景颜色接近难以阅读
- 此次无效果图, 请用心体会

> *ps: 链接懒得加了, 顺着行号应该能找到*
> *另外: 考虑添加 Source Map 以提升开发者体验*